### PR TITLE
Add Drivethru client and node

### DIFF
--- a/src/main/cpp/drivethru_client.cpp
+++ b/src/main/cpp/drivethru_client.cpp
@@ -1,0 +1,105 @@
+#include "drivethru_client.h"
+
+#include <iostream>
+
+DrivethruClient::DrivethruClient(asio::io_context& ctx)
+    : context_(ctx),
+      socket_(ctx),
+      read_buffer_(256),
+      connected_(false) {
+
+    // no-op
+}
+
+void DrivethruClient::AddPacketSubscriber(PacketSubscriber subscriber) {
+    subscribers_.push_back(subscriber);
+}
+
+void DrivethruClient::Write(const uint8_t* buffer, std::size_t size) {
+    std::vector<uint8_t> buf_vec(buffer, buffer + size);
+    auto packet = drivethru::Packetizer::makePacket(buf_vec);
+
+    asio::post(context_,
+        [this, packet]() {
+            bool write_in_progress = !message_queue_.empty();
+            message_queue_.push_back(packet);
+            if (!write_in_progress) {
+                DoWrite();
+            }
+        });
+}
+
+void DrivethruClient::Connect(const tcp::resolver::results_type& endpoints) {
+    DoConnect(endpoints);
+}
+
+bool DrivethruClient::IsConnected() {
+    return connected_;
+}
+
+void DrivethruClient::DoConnect(const tcp::resolver::results_type& endpoints) {
+    asio::async_connect(socket_, endpoints,
+        [this](std::error_code ec, tcp::endpoint) {
+            if (!ec) {
+                // TODO broadcast to listener?
+                connected_ = true;
+
+                DoReadData();
+            }
+        });
+        // TODO do we want some sort of exponential backoff retry?
+}
+
+/**
+ * Read more data
+ * This is the meat of the client, which listens for messages
+ * from the server and broadcasts available packets to listeners
+ */
+void DrivethruClient::DoReadData() {
+    // We use async_read_some (on the socket) because we don't care
+    // about delimiters, and will let the packetizer handle this
+    // for us
+    socket_.async_read_some(asio::buffer(read_buffer_),
+        [this](std::error_code ec, std::size_t length) {
+            if (!ec) {
+                packetizer_.addChunk(
+                    std::vector<uint8_t>(read_buffer_.begin(),
+                                         read_buffer_.begin() + length));
+
+                std::vector<uint8_t> buf = packetizer_.read();
+                while (buf.size() > 0) {
+                    auto env_ptr = bbfrc::msgs::GetEnvelope(buf.data());
+                    BroadcastPacket(env_ptr);
+                    buf = packetizer_.read();
+                }
+
+                // Come around for another go at reading
+                // It's async, so this basically puts some work
+                // on the io_context queue and returns
+                DoReadData();
+            }
+            // TODO Handle error codes
+        });
+}
+
+/**
+ * Write whatever is in the queue right now
+ */
+void DrivethruClient::DoWrite() {
+    asio::async_write(socket_,
+        asio::buffer(message_queue_.front()),
+        [this](std::error_code ec, std::size_t length) {
+            if (!ec) {
+                message_queue_.pop_front();
+                if (!message_queue_.empty()) {
+                    DoWrite();
+                }
+            }
+        });
+}
+
+void DrivethruClient::BroadcastPacket(const bbfrc::msgs::Envelope* envelope) {
+    for (auto it = subscribers_.begin(); it != subscribers_.end(); it++) {
+        (*it)(envelope);
+    }
+}

--- a/src/main/cpp/drivethru_dio.cpp
+++ b/src/main/cpp/drivethru_dio.cpp
@@ -1,0 +1,48 @@
+#include "drivethru_dio.h"
+
+#include <iostream>
+
+#include <mockdata/HAL_Value.h>
+#include <mockdata/DIOData.h>
+#include <mockdata/NotifyListener.h>
+
+static void init_callback(const char* name,
+                          void* param,
+                          const struct HAL_Value* value) {
+    DrivethruDIO* dio = static_cast<DrivethruDIO*>(param);
+    dio->SetInitialized(value->data.v_boolean);
+    if (dio->IsInitialized()) {
+        dio->Listen();
+    }
+}
+
+DrivethruDIO::DrivethruDIO(int port, HALSimDrivethru* halsim) {
+    port_ = port;
+    halsim_ = halsim;
+    HALSIM_RegisterDIOInitializedCallback(port, init_callback, this, true);
+
+    // TODO Investigate if the line below gets called when we do
+    // .set() on a DigitalOutput
+    // HALSIM_RegisterDIOValueCallback
+}
+
+void DrivethruDIO::SetInitialized(bool value) {
+    initialized_ = value;
+}
+
+bool DrivethruDIO::IsInitialized() {
+    return initialized_;
+}
+
+void DrivethruDIO::Listen() {
+    if (!has_listener_) {
+        has_listener_ = true;
+        halsim_->node.AddDigitalInputListener(port_, [this](int port, bool value) {
+            Callback(value);
+        });
+    }
+}
+
+void DrivethruDIO::Callback(bool value) {
+    HALSIM_SetDIOValue(port_, value);
+}

--- a/src/main/cpp/drivethru_node.cpp
+++ b/src/main/cpp/drivethru_node.cpp
@@ -1,0 +1,172 @@
+
+
+#include "drivethru_node.h"
+
+#include <iostream>
+#include "protocols/flatbuffers/flatbuffer_util.h"
+
+DrivethruNode::DrivethruNode()
+    : io_context_(),
+      client_(io_context_),
+      run_thread_(nullptr),
+      has_firmware_info_(false),
+      buffer_builder_(512) {
+
+    firmware_info_ = { "", 0, 0 };
+
+    // Add client packet listener
+    client_.AddPacketSubscriber(
+        std::bind(&DrivethruNode::OnPacketReceived,
+                  this,
+                  std::placeholders::_1));
+}
+
+DrivethruNode::~DrivethruNode() {
+    Stop();
+}
+
+bool DrivethruNode::Connect(std::string host, int port) {
+    return Connect(host, std::to_string(port));
+}
+
+bool DrivethruNode::Connect(std::string host, std::string service) {
+    if (client_.IsConnected()) {
+        return true;
+    }
+
+    tcp::resolver resolver(io_context_);
+    auto endpoints = resolver.resolve(host, service);
+    client_.Connect(endpoints);
+
+    waiting_for_firmware_ = true;
+
+    // Make a request for firmware version
+    SendFirmwareRequest();
+
+    // Start the run thread
+    run_thread_ = new std::thread([this]() { io_context_.run(); });
+
+    return true;
+}
+
+void DrivethruNode::Stop() {
+    if (run_thread_ != nullptr) {
+        run_thread_->join();
+        delete run_thread_;
+        run_thread_ = nullptr;
+    }
+}
+
+bool DrivethruNode::IsConnected() {
+    return client_.IsConnected() && has_firmware_info_;
+}
+
+// Subscriptions
+void DrivethruNode::AddOnConnectedListener(OnConnectedCallback cb) {
+    onconnected_callbacks_.push_back(cb);
+}
+
+void DrivethruNode::AddDigitalInputListener(int port, OnDigitalInputChangedCallback cb) {
+    auto it = digital_callbacks_map_.find(port);
+    if (it == digital_callbacks_map_.end()) {
+        SendDigitalSubscriptionRequest(port);
+        digital_callbacks_map_.insert(
+            std::pair<int, std::vector<OnDigitalInputChangedCallback>>(port, { cb }));
+    }
+    else {
+        it->second.push_back(cb);
+    }
+}
+
+void DrivethruNode::AddAnalogInputListener(int port, OnAnalogInputChangedCallback cb) {
+    auto it = analog_callbacks_map_.find(port);
+    if (it == analog_callbacks_map_.end()) {
+        SendAnalogSubscriptionRequest(port);
+        analog_callbacks_map_.insert(
+            std::pair<int, std::vector<OnAnalogInputChangedCallback>>(port, { cb }));
+    }
+    else {
+        it->second.push_back(cb);
+    }
+}
+
+// API
+FirmwareInfo DrivethruNode::GetFirmwareInfo() {
+    FirmwareInfo ret(firmware_info_);
+    return ret;
+}
+
+void DrivethruNode::OnPacketReceived(const bbfrc::msgs::Envelope* envelope) {
+    switch (envelope->payload_type()) {
+        case bbfrc::msgs::Payload_GetFirmwareNameAndVersionResponse: {
+            has_firmware_info_ = true;
+            auto payload = envelope->payload_as_GetFirmwareNameAndVersionResponse();
+            firmware_info_.name.assign(payload->name()->c_str());
+            firmware_info_.version_major = payload->versionMajor();
+            firmware_info_.version_minor = payload->versionMinor();
+
+            if (waiting_for_firmware_) {
+                waiting_for_firmware_ = false;
+                BroadcastOnConnected(GetFirmwareInfo());
+            }
+        } break;
+
+        case bbfrc::msgs::Payload_DigitalReadResponse: {
+            auto payload = envelope->payload_as_DigitalReadResponse();
+            BroadcastDigital(payload->port(), payload->value());
+        } break;
+
+        // TODO Implement other response handlers
+
+        default:
+            std::cout << "Unknown message type" << std::endl;
+    }
+}
+
+void DrivethruNode::SendFirmwareRequest() {
+    buffer_builder_.Reset();
+    int buf_size;
+    uint8_t* buf = FlatBuffersUtil::makeGetFirmwareNameAndVersionRequest(buffer_builder_, &buf_size);
+    client_.Write(buf, buf_size);
+}
+
+void DrivethruNode::SendDigitalSubscriptionRequest(int port) {
+    buffer_builder_.Reset();
+    int buf_size;
+    uint8_t* buf = FlatBuffersUtil::makeDigitalReadSubscribeRequest(buffer_builder_, port, true, &buf_size);
+    client_.Write(buf, buf_size);
+}
+
+void DrivethruNode::SendAnalogSubscriptionRequest(int port) {
+    buffer_builder_.Reset();
+    int buf_size;
+    uint8_t* buf = FlatBuffersUtil::makeAnalogReadSubscribeRequest(buffer_builder_, port, true, &buf_size);
+    client_.Write(buf, buf_size);
+}
+
+// Broadcast methods
+void DrivethruNode::BroadcastOnConnected(FirmwareInfo fw) {
+    for (auto it = onconnected_callbacks_.begin(); it != onconnected_callbacks_.end(); it++) {
+        (*it)(fw);
+    }
+}
+
+void DrivethruNode::BroadcastDigital(int port, bool value) {
+    auto subscribers = digital_callbacks_map_.find(port);
+    if (subscribers != digital_callbacks_map_.end()) {
+        auto subscriber_list = subscribers->second;
+        for (auto it = subscriber_list.begin(); it != subscriber_list.end(); it++) {
+            (*it)(port, value);
+        }
+    }
+}
+
+void DrivethruNode::BroadcastAnalog(int port, int value) {
+    auto subscribers = analog_callbacks_map_.find(port);
+    if (subscribers != analog_callbacks_map_.end()) {
+        auto subscriber_list = subscribers->second;
+        for (auto it = subscriber_list.begin(); it != subscriber_list.end(); it++) {
+            (*it)(port, value);
+        }
+    }
+}

--- a/src/main/cpp/drivethru_node.cpp
+++ b/src/main/cpp/drivethru_node.cpp
@@ -96,6 +96,20 @@ FirmwareInfo DrivethruNode::GetFirmwareInfo() {
     return ret;
 }
 
+void DrivethruNode::PublishDigital(int port, bool value) {
+    buffer_builder_.Reset();
+    int buf_size;
+    uint8_t* buf = FlatBuffersUtil::makeDigitalWriteRequest(buffer_builder_, port, value, &buf_size);
+    client_.Write(buf, buf_size);
+}
+
+void DrivethruNode::PublishServoAngle(int port, int angle) {
+    buffer_builder_.Reset();
+    int buf_size;
+    uint8_t* buf = FlatBuffersUtil::makeSetServoAngleRequest(buffer_builder_, port, angle, &buf_size);
+    client_.Write(buf, buf_size);
+}
+
 void DrivethruNode::OnPacketReceived(const bbfrc::msgs::Envelope* envelope) {
     switch (envelope->payload_type()) {
         case bbfrc::msgs::Payload_GetFirmwareNameAndVersionResponse: {

--- a/src/main/cpp/drivethru_pwm.cpp
+++ b/src/main/cpp/drivethru_pwm.cpp
@@ -1,0 +1,39 @@
+#include "drivethru_pwm.h"
+
+#include <string>
+
+#include <mockdata/HAL_Value.h>
+#include <mockdata/NotifyListener.h>
+#include <mockdata/PWMData.h>
+
+static void init_callback(const char* name,
+                          void* param,
+                          const struct HAL_Value* value) {
+    DrivethruPWM* pwm = static_cast<DrivethruPWM*>(param);
+    pwm->SetInitialized(value->data.v_boolean);
+}
+
+static void speed_callback(const char* name,
+                           void* param,
+                           const struct HAL_Value* value) {
+    DrivethruPWM* pwm = static_cast<DrivethruPWM*>(param);
+    if (pwm->IsInitialized()) {
+        pwm->Publish(value->data.v_double);
+    }
+}
+
+DrivethruPWM::DrivethruPWM(int port, HALSimDrivethru* halsim) {
+    port_ = port;
+    halsim_ = halsim;
+    HALSIM_RegisterPWMInitializedCallback(port, init_callback, this, true);
+    HALSIM_RegisterPWMSpeedCallback(port, speed_callback, this, true);
+}
+
+void DrivethruPWM::Publish(double value) {
+    // convert [-1.0, 1.0] to [0, 180]
+    if (value < -1.0) value = -1.0;
+    if (value > 1.0) value = 1.0;
+
+    int angle = (int)(((value + 1.0) / 2.0) * 180.0);
+    halsim_->node.PublishServoAngle(port_, angle);
+}

--- a/src/main/cpp/main.cpp
+++ b/src/main/cpp/main.cpp
@@ -2,18 +2,18 @@
  * PURELY FOR DEMO TESTING ONLY
  * PLEASE REMEMBER TO REMOVE THIS FILE AFTER YOU HAVE YOUR OWN IMPLEMENTATION
  */
-#define ASIO_STANDALONE
 
 #include <iostream>
 
 #include <hal/Ports.h>
 
 #include "HALSimPrint.h"
+
 #include "PrintPWM.h"
 
-#include <asio.hpp>
-
 #include "protocols/flatbuffers/flatbuffer_util.h"
+
+#include "drivethru_node.h"
 
 static HALSimPrint halsim;
 
@@ -24,6 +24,18 @@ __declspec(dllexport)
 
 int HALSIM_InitExtension(void) {
     std::cout << "Drivethru Print Simulator initializing..." << std::endl;
+
+    DrivethruNode node;
+    node.AddOnConnectedListener([](FirmwareInfo fw) {
+        std::cout << "Connected with firmware " << fw.name << "-" << fw.version_major << "." << fw.version_minor << std::endl;
+    });
+
+    node.AddDigitalInputListener(0, [](int port, bool value) {
+        std::cout << "Digital Port " << port << " value: " << value << std::endl;
+    });
+
+    node.Connect("localhost", 9001);
+
 
     int pwmCount = HAL_GetNumPWMChannels();
     halsim.m_pwms.reserve(pwmCount);
@@ -55,7 +67,6 @@ int HALSIM_InitExtension(void) {
     auto envelope = bbfrc::msgs::GetEnvelope(buf);
 
     // here, envelope->payload_type() tells us what the type of message the payload is
-
 
     return 0;
 }

--- a/src/main/include/drivethru_client.h
+++ b/src/main/include/drivethru_client.h
@@ -1,0 +1,41 @@
+#pragma once
+#define ASIO_STANDALONE
+
+#include <asio.hpp>
+#include <memory>
+#include <deque>
+
+#include "util/packetizer.h"
+#include "protocols/flatbuffers/drivethru_generated.h"
+
+using asio::ip::tcp;
+
+typedef std::function<void(const bbfrc::msgs::Envelope*)> PacketSubscriber;
+
+class DrivethruClient {
+public:
+    DrivethruClient(asio::io_context& ctx);
+    void AddPacketSubscriber(PacketSubscriber subscriber);
+
+    void Write(const uint8_t* buffer, std::size_t size);
+
+    void Connect(const tcp::resolver::results_type& endpoints);
+    bool IsConnected();
+
+private:
+    void DoConnect(const tcp::resolver::results_type& endpoints);
+    void DoReadData();
+    void DoWrite();
+    void BroadcastPacket(const bbfrc::msgs::Envelope* envelope);
+
+private:
+    asio::io_context& context_;
+    tcp::socket socket_;
+    std::vector<uint8_t> read_buffer_;
+    std::vector<PacketSubscriber> subscribers_;
+    drivethru::Packetizer packetizer_;
+
+    bool connected_;
+
+    std::deque<std::vector<uint8_t>> message_queue_;
+};

--- a/src/main/include/drivethru_dio.h
+++ b/src/main/include/drivethru_dio.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "halsim_drivethru.h"
+
+class DrivethruDIO {
+public:
+    DrivethruDIO(int port, HALSimDrivethru* halsim);
+    void SetInitialized(bool value);
+    bool IsInitialized();
+    void Listen();
+
+private:
+    HALSimDrivethru* halsim_;
+    int port_;
+    bool initialized_;
+
+    void Callback(bool value);
+
+    bool has_listener_;
+};

--- a/src/main/include/drivethru_node.h
+++ b/src/main/include/drivethru_node.h
@@ -37,6 +37,8 @@ public:
 
     // API
     FirmwareInfo GetFirmwareInfo();
+    void PublishDigital(int port, bool value);
+    void PublishServoAngle(int port, int angle);
 
 private:
     void OnPacketReceived(const bbfrc::msgs::Envelope* envelope);

--- a/src/main/include/drivethru_node.h
+++ b/src/main/include/drivethru_node.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#define ASIO_STANDALONE
+
+#include <asio.hpp>
+#include <thread>
+#include <map>
+
+#include "drivethru_client.h"
+
+typedef struct FirmwareInfo {
+    std::string name;
+    unsigned int version_major;
+    unsigned int version_minor;
+} FirmwareInfo;
+
+// Callback signatures
+typedef std::function<void(FirmwareInfo)> OnConnectedCallback;
+typedef std::function<void(int, bool)> OnDigitalInputChangedCallback;
+typedef std::function<void(int, int)> OnAnalogInputChangedCallback;
+
+class DrivethruNode {
+public:
+    DrivethruNode();
+    ~DrivethruNode();
+
+    bool Connect(std::string host, int port);
+    bool Connect(std::string host, std::string port);
+    void Stop();
+
+    bool IsConnected();
+
+    // Subscriptions
+    void AddOnConnectedListener(OnConnectedCallback callback);
+    void AddDigitalInputListener(int port, OnDigitalInputChangedCallback callback);
+    void AddAnalogInputListener(int port, OnAnalogInputChangedCallback callback);
+
+    // API
+    FirmwareInfo GetFirmwareInfo();
+
+private:
+    void OnPacketReceived(const bbfrc::msgs::Envelope* envelope);
+
+    // Convenience functions for sending packets
+    void SendFirmwareRequest();
+    void SendDigitalSubscriptionRequest(int port);
+    void SendAnalogSubscriptionRequest(int port);
+
+    // Broadcast
+    void BroadcastOnConnected(FirmwareInfo fw_info);
+    void BroadcastDigital(int port, bool value);
+    void BroadcastAnalog(int port, int value);
+
+private:
+    asio::io_context io_context_;
+    DrivethruClient client_;
+    std::thread* run_thread_;
+
+    flatbuffers::FlatBufferBuilder buffer_builder_;
+
+    bool waiting_for_firmware_;
+    bool has_firmware_info_;
+    FirmwareInfo firmware_info_;
+
+    // Subscriptions
+    std::vector<OnConnectedCallback> onconnected_callbacks_;
+    std::map<int, std::vector<OnDigitalInputChangedCallback>> digital_callbacks_map_;
+    std::map<int, std::vector<OnAnalogInputChangedCallback>> analog_callbacks_map_;
+};

--- a/src/main/include/drivethru_pwm.h
+++ b/src/main/include/drivethru_pwm.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "halsim_drivethru.h"
+
+class DrivethruPWM {
+public:
+    DrivethruPWM(int port, HALSimDrivethru* halsim);
+    void SetInitialized(bool value) { initialized_ = value; }
+    bool IsInitialized() { return initialized_; }
+    void Publish(double value);
+
+private:
+    HALSimDrivethru* halsim_;
+    bool initialized_;
+    int port_;
+};

--- a/src/main/include/halsim_drivethru.h
+++ b/src/main/include/halsim_drivethru.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <vector>
+#include "drivethru_node.h"
+
+class DrivethruDIO;
+class DrivethruPWM;
+
+class HALSimDrivethru {
+public:
+    static const int kPwmCount = 10;
+
+    DrivethruNode node;
+
+    std::vector<DrivethruPWM*> pwms;
+    std::vector<DrivethruDIO*> dios;
+};


### PR DESCRIPTION
This commit introduces the drivethru connection mechanism. The drivethru
client is responsible for TCP communication with the drivethru server,
while the drivethru node is responsible for higher level event
broadcasting.